### PR TITLE
fix(stringToHeaders): support empty headers string

### DIFF
--- a/src/transformers/stringToHeaders.test.ts
+++ b/src/transformers/stringToHeaders.test.ts
@@ -1,9 +1,8 @@
 import HeadersPolyfill from '../Headers'
 import { stringToHeaders } from './stringToHeaders'
 
-describe('given a string representation of headers', () => {
-  it('returns a Headers instance', () => {
-    const headersString = `
+it('returns a Headers instance given a headers string', () => {
+  const headersString = `
 date: Fri, 08 Dec 2017 21:04:30 GMT\r\n
 content-encoding: gzip\r\n
 x-content-type-options: nosniff\r\n
@@ -15,18 +14,23 @@ vary: Cookie, Accept-Encoding\r\n
 content-length: 6502\r\n
 x-xss-protection: 1; mode=block\r\n
       `
-    const headers = stringToHeaders(headersString)
+  const headers = stringToHeaders(headersString)
 
-    expect(headers).toBeInstanceOf(HeadersPolyfill)
-    expect(headers.get('date')).toEqual('Fri, 08 Dec 2017 21:04:30 GMT')
-    expect(headers.get('content-encoding')).toEqual('gzip')
-    expect(headers.get('x-content-type-options')).toEqual('nosniff')
-    expect(headers.get('server')).toEqual('meinheld/0.6.1')
-    expect(headers.get('x-frame-options')).toEqual('DENY')
-    expect(headers.get('content-type')).toEqual('text/html; charset=utf-8')
-    expect(headers.get('connection')).toEqual('keep-alive')
-    expect(headers.get('vary')).toEqual('Cookie, Accept-Encoding')
-    expect(headers.get('content-length')).toEqual('6502')
-    expect(headers.get('x-xss-protection')).toEqual('1; mode=block')
-  })
+  expect(headers).toBeInstanceOf(HeadersPolyfill)
+  expect(headers.get('date')).toEqual('Fri, 08 Dec 2017 21:04:30 GMT')
+  expect(headers.get('content-encoding')).toEqual('gzip')
+  expect(headers.get('x-content-type-options')).toEqual('nosniff')
+  expect(headers.get('server')).toEqual('meinheld/0.6.1')
+  expect(headers.get('x-frame-options')).toEqual('DENY')
+  expect(headers.get('content-type')).toEqual('text/html; charset=utf-8')
+  expect(headers.get('connection')).toEqual('keep-alive')
+  expect(headers.get('vary')).toEqual('Cookie, Accept-Encoding')
+  expect(headers.get('content-length')).toEqual('6502')
+  expect(headers.get('x-xss-protection')).toEqual('1; mode=block')
+})
+
+it('returns a Headers instance given an empty string', () => {
+  const headers = stringToHeaders('')
+  expect(headers).toBeInstanceOf(HeadersPolyfill)
+  expect(headers.all()).toEqual({})
 })

--- a/src/transformers/stringToHeaders.ts
+++ b/src/transformers/stringToHeaders.ts
@@ -8,6 +8,10 @@ export function stringToHeaders(str: string): HeadersPolyfill {
   const lines = str.trim().split(/[\r\n]+/)
 
   return lines.reduce((headers, line) => {
+    if (line.trim() === '') {
+      return headers
+    }
+
     const parts = line.split(': ')
     const name = parts.shift()
     const value = parts.join(': ')


### PR DESCRIPTION
- Closes https://github.com/mswjs/interceptors/issues/211