### PR TITLE
fix: use "es5" as the compile target

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compileOnSave": true,
   "compilerOptions": {
-    "target": "esnext",
+    "target": "ES5",
     "module": "CommonJS",
     "outDir": "lib",
     "declaration": true,


### PR DESCRIPTION
PR created based on https://github.com/mswjs/headers-polyfill/issues/36#issuecomment-1181563017
