### PR TITLE
add `lib` export back to package to avoid breaking

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,11 @@
       "types": "./lib/index.d.ts",
       "require": "./lib/index.js",
       "default": "./lib/esm/index.js"
+    },
+    "./lib": {
+      "types": "./lib/index.d.ts",
+      "require": "./lib/index.js",
+      "default": "./lib/esm/index.js"
     }
   },
   "repository": "https://github.com/mswjs/headers-polyfill",


### PR DESCRIPTION
While `lib` was not the official import path, it appears some were using this. 

We can add it back now, and remove it in a major, to avoid headache

fixes https://github.com/mswjs/headers-polyfill/issues/41