### PR TITLE
fix: output esm into "*.mjs" module

### DIFF
--- a/esm/package.json
+++ b/esm/package.json
@@ -1,6 +1,0 @@
-{
-    "main": "../lib/esm/index.js",
-    "module": "../lib/esm/index.js",
-    "types": "../lib/index.d.ts"
-  }
-  

--- a/package.json
+++ b/package.json
@@ -3,13 +3,13 @@
   "version": "3.1.0",
   "description": "A native \"Headers\" class polyfill.",
   "main": "./lib/index.js",
-  "module": "./lib/esm/index.js",
+  "module": "./lib/index.mjs",
   "types": "./lib/index.d.ts",
   "exports": {
     ".": {
       "types": "./lib/index.d.ts",
       "require": "./lib/index.js",
-      "default": "./lib/esm/index.js"
+      "default": "./lib/index.mjs"
     }
   },
   "repository": "https://github.com/mswjs/headers-polyfill",

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -6,7 +6,6 @@ export default defineConfig([
     entry: ['./src/index.ts'],
     outDir: './lib',
     format: ['esm','cjs'],
-    legacyOutput: true,
     sourcemap: true,
     clean: true,
     bundle: true,


### PR DESCRIPTION
Removes legacyOutput option from tsup, in favor the `mjs` output used without that configuration.

removes unnecessary `esm` folder and package.json

output of lib with this config (to compare against). 

<img width="472" alt="Screen Shot 2022-10-05 at 8 49 38 PM" src="https://user-images.githubusercontent.com/8616962/194189350-e6bea4c3-563a-4342-b6b2-033a58eda2e3.png">

I haven't published/tested node resolution here - this might be helpful before versioning/merging