### PR TITLE
Add "./lib" subpath to "exports" to fix subpath issues with version dependent packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
       "types": "./lib/index.d.ts",
       "require": "./lib/index.js",
       "default": "./lib/index.mjs"
-    }
+    },
+    "./lib": "./lib/index.js"
   },
   "repository": "https://github.com/mswjs/headers-polyfill",
   "author": "Artem Zakharchenko",


### PR DESCRIPTION
This will fix the error `"Package subpath './lib' is not defined by "exports" ...` for packages depending on this library.

Resolves the following issues:
- https://github.com/mswjs/headers-polyfill/issues/50
- https://github.com/mswjs/headers-polyfill/issues/51