### PR TITLE
feat: implements "getSetCookie" method on Headers

### DIFF
--- a/src/Headers.test.ts
+++ b/src/Headers.test.ts
@@ -186,6 +186,11 @@ describe('.get()', () => {
     expect(headers.get('Accept')).toBeNull()
     expect(headers.get('AcCePt')).toBeNull()
   })
+
+  it('return an empty string for an empty header value', () => {
+    const headers = new Headers({ 'Content-Type': '' })
+    expect(headers.get('Content-Type')).toEqual('')
+  })
 })
 
 describe('.all()', () => {
@@ -333,12 +338,14 @@ describe('.forEach()', () => {
 
 describe('.getSetCookie()', () => {
   it('returns the value of the existing Set-Cookie header', () => {
-    const headers = new Headers({ 'Set-Cookie': 'a' })
-    expect(headers.getSetCookie()).toEqual(['a'])
+    const headers = new Headers({ 'Set-Cookie': '' })
+    expect(headers.getSetCookie()).toEqual([''])
+    headers.append('Set-Cookie', 'a')
+    expect(headers.getSetCookie()).toEqual(['', 'a'])
     headers.append('Set-Cookie', 'b')
-    expect(headers.getSetCookie()).toEqual(['a', 'b'])
+    expect(headers.getSetCookie()).toEqual(['', 'a', 'b'])
     headers.append('Set-Cookie', 'c')
-    expect(headers.getSetCookie()).toEqual(['a', 'b', 'c'])
+    expect(headers.getSetCookie()).toEqual(['', 'a', 'b', 'c'])
   })
 
   it('returns [] given a non-existing Set-Cookie header', () => {

--- a/src/Headers.test.ts
+++ b/src/Headers.test.ts
@@ -59,7 +59,7 @@ describe('[Symbol.iterator]', () => {
       'content-type': 'application/json',
     })
 
-    const entries = []
+    const entries: Array<[string, string]> = []
 
     for (const entry of headers) {
       entries.push(entry)
@@ -74,7 +74,7 @@ describe('[Symbol.iterator]', () => {
 
   it('returns an empty iterator when there is no headers', () => {
     const headers = new Headers()
-    const entries = []
+    const entries: Array<[string, string]> = []
 
     for (const entry of headers) {
       entries.push(entry)
@@ -91,7 +91,7 @@ describe('.keys()', () => {
       'accept-language': 'en-US',
       'content-type': 'application/json',
     })
-    const keys = []
+    const keys: Array<string> = []
 
     for (const name of headers.keys()) {
       keys.push(name)
@@ -102,7 +102,7 @@ describe('.keys()', () => {
 
   it('returns an empty iterator when there is no headers', () => {
     const headers = new Headers()
-    const keys = []
+    const keys: Array<string> = []
 
     for (const name of headers.keys()) {
       keys.push(name)
@@ -119,7 +119,7 @@ describe('.values()', () => {
       'accept-language': 'en-US',
       'content-type': 'application/json',
     })
-    const values = []
+    const values: Array<string> = []
 
     for (const value of headers.values()) {
       values.push(value)
@@ -130,7 +130,7 @@ describe('.values()', () => {
 
   it('returns an empty iterator when there is no headers', () => {
     const headers = new Headers()
-    const values = []
+    const values: Array<string> = []
 
     for (const value of headers.values()) {
       values.push(value)
@@ -147,7 +147,7 @@ describe('.entries()', () => {
       'accept-language': 'en-US',
       'content-type': 'application/json',
     })
-    const entries = []
+    const entries: Array<[string, string]> = []
 
     for (const entry of headers.entries()) {
       entries.push(entry)
@@ -162,7 +162,7 @@ describe('.entries()', () => {
 
   it('returns an empty iterator when there is no headers', () => {
     const headers = new Headers()
-    const entries = []
+    const entries: Array<[string, string]> = []
 
     for (const entry of headers.entries()) {
       entries.push(entry)
@@ -328,5 +328,21 @@ describe('.forEach()', () => {
     }, headerSet)
 
     expect(headerSet).toEqual(new Set(['accept', 'user-agent']))
+  })
+})
+
+describe('.getSetCookie()', () => {
+  it('returns the value of the existing Set-Cookie header', () => {
+    const headers = new Headers({ 'Set-Cookie': 'a' })
+    expect(headers.getSetCookie()).toEqual(['a'])
+    headers.append('Set-Cookie', 'b')
+    expect(headers.getSetCookie()).toEqual(['a', 'b'])
+    headers.append('Set-Cookie', 'c')
+    expect(headers.getSetCookie()).toEqual(['a', 'b', 'c'])
+  })
+
+  it('returns [] given a non-existing Set-Cookie header', () => {
+    const headers = new Headers()
+    expect(headers.getSetCookie()).toEqual([])
   })
 })

--- a/src/Headers.ts
+++ b/src/Headers.ts
@@ -158,7 +158,7 @@ export default class HeadersPolyfill {
 
   getSetCookie(): string[] {
     const setCookieHeader =
-      this[NORMALIZED_HEADERS][SET_COOKIE_HEADER_KEY_NORMALIZED]
-    return setCookieHeader ? setCookieHeader.split(HEADER_JOIN_DELIMITER) : []
+      this[NORMALIZED_HEADERS][SET_COOKIE_HEADER_KEY_NORMALIZED] ?? ''
+    return setCookieHeader.split(HEADER_JOIN_DELIMITER)
   }
 }

--- a/src/Headers.ts
+++ b/src/Headers.ts
@@ -4,6 +4,8 @@ import { normalizeHeaderValue } from './utils/normalizeHeaderValue'
 
 const NORMALIZED_HEADERS: unique symbol = Symbol('normalizedHeaders')
 const RAW_HEADER_NAMES: unique symbol = Symbol('rawHeaderNames')
+const HEADER_JOIN_DELIMITER = ', ' as const
+const SET_COOKIE_HEADER_KEY_NORMALIZED = 'set-cookie' as const
 
 export default class HeadersPolyfill {
   // Normalized header {"name":"a, b"} storage.
@@ -28,12 +30,18 @@ export default class HeadersPolyfill {
       }, this)
     } else if (Array.isArray(init)) {
       init.forEach(([name, value]) => {
-        this.append(name, Array.isArray(value) ? value.join(', ') : value)
+        this.append(
+          name,
+          Array.isArray(value) ? value.join(HEADER_JOIN_DELIMITER) : value
+        )
       })
     } else if (init) {
       Object.getOwnPropertyNames(init).forEach((name) => {
         const value = init[name]
-        this.append(name, Array.isArray(value) ? value.join(', ') : value)
+        this.append(
+          name,
+          Array.isArray(value) ? value.join(HEADER_JOIN_DELIMITER) : value
+        )
       })
     }
   }
@@ -146,5 +154,11 @@ export default class HeadersPolyfill {
         callback.call(thisArg, this[NORMALIZED_HEADERS][name], name, this)
       }
     }
+  }
+
+  getSetCookie(): string[] {
+    const setCookieHeader =
+      this[NORMALIZED_HEADERS][SET_COOKIE_HEADER_KEY_NORMALIZED]
+    return setCookieHeader ? setCookieHeader.split(HEADER_JOIN_DELIMITER) : []
   }
 }

--- a/src/Headers.ts
+++ b/src/Headers.ts
@@ -4,8 +4,7 @@ import { normalizeHeaderValue } from './utils/normalizeHeaderValue'
 
 const NORMALIZED_HEADERS: unique symbol = Symbol('normalizedHeaders')
 const RAW_HEADER_NAMES: unique symbol = Symbol('rawHeaderNames')
-const HEADER_JOIN_DELIMITER = ', ' as const
-const SET_COOKIE_HEADER_KEY_NORMALIZED = 'set-cookie' as const
+const HEADER_VALUE_DELIMITER = ', ' as const
 
 export default class HeadersPolyfill {
   // Normalized header {"name":"a, b"} storage.
@@ -32,7 +31,7 @@ export default class HeadersPolyfill {
       init.forEach(([name, value]) => {
         this.append(
           name,
-          Array.isArray(value) ? value.join(HEADER_JOIN_DELIMITER) : value
+          Array.isArray(value) ? value.join(HEADER_VALUE_DELIMITER) : value
         )
       })
     } else if (init) {
@@ -40,7 +39,7 @@ export default class HeadersPolyfill {
         const value = init[name]
         this.append(
           name,
-          Array.isArray(value) ? value.join(HEADER_JOIN_DELIMITER) : value
+          Array.isArray(value) ? value.join(HEADER_VALUE_DELIMITER) : value
         )
       })
     }
@@ -72,7 +71,7 @@ export default class HeadersPolyfill {
    * Returns a `ByteString` sequence of all the values of a header with a given name.
    */
   get(name: string): string | null {
-    return this[NORMALIZED_HEADERS][normalizeHeaderName(name)] || null
+    return this[NORMALIZED_HEADERS][normalizeHeaderName(name)] ?? null
   }
 
   /**
@@ -162,8 +161,8 @@ export default class HeadersPolyfill {
    * with a response
    */
   getSetCookie(): string[] {
-    const setCookieHeader =
-      this[NORMALIZED_HEADERS][SET_COOKIE_HEADER_KEY_NORMALIZED] ?? ''
-    return setCookieHeader.split(HEADER_JOIN_DELIMITER)
+    const setCookieHeader = this.get('set-cookie')
+    if (setCookieHeader === null) return []
+    return setCookieHeader.split(HEADER_VALUE_DELIMITER)
   }
 }

--- a/src/Headers.ts
+++ b/src/Headers.ts
@@ -156,6 +156,11 @@ export default class HeadersPolyfill {
     }
   }
 
+  /**
+   * Returns an array containing the values
+   * of all Set-Cookie headers associated
+   * with a response
+   */
   getSetCookie(): string[] {
     const setCookieHeader =
       this[NORMALIZED_HEADERS][SET_COOKIE_HEADER_KEY_NORMALIZED] ?? ''


### PR DESCRIPTION
Related to https://github.com/mswjs/msw/pull/1711#issuecomment-1693949312

This PR implements the `getSetCookie` method on the `Headers` class, adds a few tests as well. 

Notice a few red squiggles in the editor, in the test files, so added type annotations to avoid seeing them

Extracted the `', '` join delimiter used when appending headers to avoid potential typos, since it's used in a few places, including the newly added code

updates `.get()` to properly return empty string values, where it previously would return `null`