### PR TITLE
fix: bundle "set- cookie-parser" to prevent module resolution issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ The `Headers` polyfill instance supports the same methods as the standard `Heade
 - [`.set()`](https://developer.mozilla.org/en-US/docs/Web/API/Headers/set)
 - [`.append()`](https://developer.mozilla.org/en-US/docs/Web/API/Headers/append)
 - [`.delete()`](https://developer.mozilla.org/en-US/docs/Web/API/Headers/delete)
-- `.forEach()`
+- [`.forEach()`](https://developer.mozilla.org/en-US/docs/Web/API/Headers/forEach)
+- [`.getSetCookie()`](https://developer.mozilla.org/en-US/docs/Web/API/Headers/getSetCookie)
 
 As well as the iterator methods:
 

--- a/package.json
+++ b/package.json
@@ -29,16 +29,14 @@
   ],
   "devDependencies": {
     "@ossjs/release": "^0.7.2",
+    "@types/set-cookie-parser": "^2.4.3",
     "@types/jest": "^28.1.4",
     "jest": "^28.1.2",
     "jest-environment-jsdom": "^28.1.2",
     "rimraf": "^3.0.2",
+    "set-cookie-parser": "^2.6.0",
     "ts-jest": "^28.0.5",
     "tsup": "^6.2.3",
     "typescript": "4.3.2"
-  },
-  "dependencies": {
-    "@types/set-cookie-parser": "^2.4.3",
-    "set-cookie-parser": "^2.6.0"
   }
 }


### PR DESCRIPTION
fixes #62 

Instead of externalizing `set-cookie-parser` which has no `esm` shipped code, this bundles it into headers-polyfill - which should alleviate issues with non-esm environments and esm environments