### PR TITLE
Add sorting to Headers.entries

### DIFF
--- a/src/Headers.test.ts
+++ b/src/Headers.test.ts
@@ -110,6 +110,21 @@ describe('.keys()', () => {
 
     expect(keys).toEqual([])
   })
+
+  it('sorts alphabetically', () => {
+    const headers = new Headers()
+    headers.set('X-B', '1')
+    headers.set('X-A', '2')
+    headers.set('X-C', '3')
+    expect(Array.from(headers.keys())).toEqual(['x-a', 'x-b', 'x-c'])
+  })
+
+  it('does not combine set-cookie headers', () => {
+    const headers = new Headers()
+    headers.append('Set-Cookie', 'a=1')
+    headers.append('Set-Cookie', 'b=2')
+    expect(Array.from(headers.keys())).toEqual(['set-cookie', 'set-cookie'])
+  })
 })
 
 describe('.values()', () => {
@@ -137,6 +152,21 @@ describe('.values()', () => {
     }
 
     expect(values).toEqual([])
+  })
+
+  it('sorts alphabetically', () => {
+    const headers = new Headers()
+    headers.set('X-B', '1')
+    headers.set('X-A', '2')
+    headers.set('X-C', '3')
+    expect(Array.from(headers.values())).toEqual(['2', '1', '3'])
+  })
+
+  it('does not combine set-cookie headers', () => {
+    const headers = new Headers()
+    headers.append('Set-Cookie', 'a=1')
+    headers.append('Set-Cookie', 'b=2')
+    expect(Array.from(headers.values())).toEqual(['a=1', 'b=2'])
   })
 })
 
@@ -169,6 +199,28 @@ describe('.entries()', () => {
     }
 
     expect(entries).toEqual([])
+  })
+
+  it('sorts alphabetically', () => {
+    const headers = new Headers()
+    headers.set('X-B', '1')
+    headers.set('X-A', '2')
+    headers.set('X-C', '3')
+    expect(Array.from(headers.entries())).toEqual([
+      ['x-a', '2'],
+      ['x-b', '1'],
+      ['x-c', '3'],
+    ])
+  })
+
+  it('does not combine set-cookie headers', () => {
+    const headers = new Headers()
+    headers.append('Set-Cookie', 'a=1')
+    headers.append('Set-Cookie', 'b=2')
+    expect(Array.from(headers.entries())).toEqual([
+      ['set-cookie', 'a=1'],
+      ['set-cookie', 'b=2'],
+    ])
   })
 })
 

--- a/src/Headers.ts
+++ b/src/Headers.ts
@@ -51,20 +51,30 @@ export default class HeadersPolyfill {
   }
 
   *keys(): IterableIterator<string> {
-    for (const name of Object.keys(this[NORMALIZED_HEADERS])) {
+    for (const [name] of this.entries()) {
       yield name
     }
   }
 
   *values(): IterableIterator<string> {
-    for (const value of Object.values(this[NORMALIZED_HEADERS])) {
+    for (const [, value] of this.entries()) {
       yield value
     }
   }
 
   *entries(): IterableIterator<[string, string]> {
-    for (const name of Object.keys(this[NORMALIZED_HEADERS])) {
-      yield [name, this.get(name)]
+    // https://fetch.spec.whatwg.org/#concept-header-list-sort-and-combine
+    let sortedKeys = Object.keys(this[NORMALIZED_HEADERS]).sort((a, b) =>
+      a.localeCompare(b)
+    )
+    for (const name of sortedKeys) {
+      if (name === 'set-cookie') {
+        for (const value of this.getSetCookie()) {
+          yield [name, value]
+        }
+      } else {
+        yield [name, this.get(name)]
+      }
     }
   }
 


### PR DESCRIPTION
Sorts `Headers.entries`/`keys`/`values` according to https://fetch.spec.whatwg.org/#concept-header-list-sort-and-combine.

For reference, I noticed this difference in Remix integration tests and ran the following program in Node 20 to compare behaviors between the built-in, the current Remix polyfill, and this polyfill:

```js
const { Headers: HeadersRemix } = require("@remix-run/web-fetch");
const { Headers: HeadersPolyfill } = require("headers-polyfill");

function testHeaders(HeadersConstructor, label) {
  let h = new HeadersConstructor();
  h.set("X-B", "1");
  h.set("X-A", "2");
  h.append("X-C", "3");
  h.append("X-C", "4");
  h.append("Set-Cookie", "e=5");
  h.append("Set-Cookie", "d=6");
  console.log(`Using ${label}:\n`, JSON.stringify(Array.from(h.entries())));
}

testHeaders(Headers, "node builtin");
testHeaders(HeadersRemix, "@remix-run/web-fetch");
testHeaders(HeadersPolyfill, "headers-polyfill");
```