### PR TITLE
fix: support global "_Headers" in Undici 5.26.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,17 +5,14 @@ on:
     branches:
       - main
   pull_request:
-    branches:
-      - main
+  workflow_dispatch:
 
 jobs:
   build:
     runs-on: ubuntu-latest
-
     strategy:
       matrix:
         node-version: [16, 18]
-
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -35,37 +32,3 @@ jobs:
 
       - name: Unit tests
         run: yarn test
-
-  release:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-          token: ${{ secrets.GH_ADMIN_TOKEN }}
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version: 16
-          always-auth: true
-          cache: yarn
-
-      - name: Setup Git
-        run: |
-          git config --local user.name "kettanaito"
-          git config --local user.email "kettanaito@gmail.com"
-
-      - name: Install dependencies
-        run: yarn install --frozen-lockfile
-
-      - name: Build
-        run: yarn build
-
-      - name: Release
-        if: contains(github.ref, 'refs/heads/main')
-        run: yarn release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_ADMIN_TOKEN }}
-          NPM_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,33 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [16, 18]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GH_ADMIN_TOKEN }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+          always-auth: true
+          cache: yarn
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Unit tests
+        run: yarn test
+
+  release:
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -32,9 +59,6 @@ jobs:
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile
-
-      - name: Unit tests
-        run: yarn test
 
       - name: Build
         run: yarn build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,42 @@
+name: release
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GH_ADMIN_TOKEN }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          always-auth: true
+          cache: yarn
+
+      - name: Setup Git
+        run: |
+          git config --local user.name "kettanaito"
+          git config --local user.email "kettanaito@gmail.com"
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Build
+        run: yarn build
+
+      - name: Release
+        if: contains(github.ref, 'refs/heads/main')
+        run: yarn release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_ADMIN_TOKEN }}
+          NPM_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/src/Headers.ts
+++ b/src/Headers.ts
@@ -21,12 +21,13 @@ export class Headers {
 
   constructor(init?: HeadersInit | HeadersObject | HeadersList) {
     /**
-     * @note Cannot check if the `init` is an instance of the `Headers`
-     * because that class is only defined in the browser.
+     * @note Cannot necessarily check if the `init` is an instance of the
+     * `Headers` because that class may not be defined in Node or jsdom.
      */
     if (
-      ['Headers', 'HeadersPolyfill', '_Headers'].includes(init?.constructor.name) ||
-      init instanceof Headers
+      ['Headers', 'HeadersPolyfill'].includes(init?.constructor.name) ||
+      init instanceof Headers ||
+      (typeof globalThis.Headers !== 'undefined' && init instanceof globalThis.Headers)
     ) {
       const initialHeaders = init as Headers
       initialHeaders.forEach((value, name) => {

--- a/src/Headers.ts
+++ b/src/Headers.ts
@@ -25,7 +25,7 @@ export class Headers {
      * because that class is only defined in the browser.
      */
     if (
-      ['Headers', 'HeadersPolyfill'].includes(init?.constructor.name) ||
+      ['Headers', 'HeadersPolyfill', '_Headers'].includes(init?.constructor.name) ||
       init instanceof Headers
     ) {
       const initialHeaders = init as Headers


### PR DESCRIPTION
Node.js's update to Undici 5.26.3 caused its `Headers` class to be called `_Headers`:

https://github.com/nodejs/node/pull/50153/files#diff-f516ab824a7722da938a4c7c851520d39731ddeb4f7198dff4e932c5d4f8fdf7

Fixes #72.